### PR TITLE
Ignore `node_modules` when copying the TS code for deno

### DIFF
--- a/mcp_run_python/main.py
+++ b/mcp_run_python/main.py
@@ -105,7 +105,7 @@ def prepare_deno_env(
     try:
         src = Path(__file__).parent / 'deno'
         logger.debug('Copying from %s to %s...', src, cwd)
-        shutil.copytree(src, cwd)
+        shutil.copytree(src, cwd, ignore=shutil.ignore_patterns('node_modules'))
         logger.info('Installing dependencies %s...', dependencies)
 
         args = 'deno', *_deno_install_args(dependencies)


### PR DESCRIPTION
Some time when testing locally, the copy operation copies the entire node_modules, and is very time consuming.

Ignore the node_modules when copying files, deno will sync from the lock file.